### PR TITLE
Convert leftover Markdown formatting to HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -902,7 +902,7 @@
             are satisfied with <a href="http://krijnhoetmer.nl/irc-logs/">Krijn Hoetmer’s setup</a>.
             Its limitations are largely that it requires getting agreement from Krijn in order to
             get something logged, and it wouldn’t scale to the many channels we would want to log.
-            The RICG also uses a simple [Drupal-based PHP setup](https://www.drupal.org/project/bot) 
+            The RICG also uses a simple <a href="https://www.drupal.org/project/bot">Drupal-based PHP setup</a> 
             to reference discussion, retrive to GitHub issue information, and for minute-taking. 
           </p>
           <p>


### PR DESCRIPTION
The reference to the Drupal IRC bot was not a hyperlink because it used Markdown formatting instead of HTML.